### PR TITLE
Switch to pypdf

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -640,22 +640,22 @@ files = [
 ]
 
 [[package]]
-name = "pypdf2"
-version = "3.0.1"
+name = "pypdf"
+version = "4.3.1"
 description = "A pure-python PDF library capable of splitting, merging, cropping, and transforming PDF files"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "PyPDF2-3.0.1.tar.gz", hash = "sha256:a74408f69ba6271f71b9352ef4ed03dc53a31aa404d29b5d31f53bfecfee1440"},
-    {file = "pypdf2-3.0.1-py3-none-any.whl", hash = "sha256:d16e4205cfee272fbdc0568b68d82be796540b1537508cef59388f839c191928"},
+    {file = "pypdf-4.3.1-py3-none-any.whl", hash = "sha256:64b31da97eda0771ef22edb1bfecd5deee4b72c3d1736b7df2689805076d6418"},
+    {file = "pypdf-4.3.1.tar.gz", hash = "sha256:b2f37fe9a3030aa97ca86067a56ba3f9d3565f9a791b305c7355d8392c30d91b"},
 ]
 
 [package.extras]
-crypto = ["PyCryptodome"]
-dev = ["black", "flit", "pip-tools", "pre-commit (<2.18.0)", "pytest-cov", "wheel"]
+crypto = ["PyCryptodome", "cryptography"]
+dev = ["black", "flit", "pip-tools", "pre-commit (<2.18.0)", "pytest-cov", "pytest-socket", "pytest-timeout", "pytest-xdist", "wheel"]
 docs = ["myst_parser", "sphinx", "sphinx_rtd_theme"]
-full = ["Pillow", "PyCryptodome"]
-image = ["Pillow"]
+full = ["Pillow (>=8.0.0)", "PyCryptodome", "cryptography"]
+image = ["Pillow (>=8.0.0)"]
 
 [[package]]
 name = "pytest"
@@ -925,4 +925,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "5c5bdbe84b1ae3d00d38ac2087089ea6754521f73e413a4773a854601d518574"
+content-hash = "c88b3e8a02b606b257bbdcfaa5da05fe157ff36183a4c332dd612951101b104c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ pytz = "^2024.1"
 python-dotenv = "^1.0.1"
 pytest = "^8.3.2"
 tqdm = "^4.66.5"
-pypdf2 = "^3.0.1"
 moto = "^5.0.12"
 natsort = "^8.4.0"
+pypdf = "^4.3.1"
 
 
 [build-system]

--- a/requirements.txt
+++ b/requirements.txt
@@ -364,9 +364,9 @@ pluggy==1.5.0 ; python_version >= "3.11" and python_version < "4.0" \
 pycparser==2.22 ; python_version >= "3.11" and python_version < "4.0" and platform_python_implementation != "PyPy" \
     --hash=sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6 \
     --hash=sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc
-pypdf2==3.0.1 ; python_version >= "3.11" and python_version < "4.0" \
-    --hash=sha256:a74408f69ba6271f71b9352ef4ed03dc53a31aa404d29b5d31f53bfecfee1440 \
-    --hash=sha256:d16e4205cfee272fbdc0568b68d82be796540b1537508cef59388f839c191928
+pypdf==4.3.1 ; python_version >= "3.11" and python_version < "4.0" \
+    --hash=sha256:64b31da97eda0771ef22edb1bfecd5deee4b72c3d1736b7df2689805076d6418 \
+    --hash=sha256:b2f37fe9a3030aa97ca86067a56ba3f9d3565f9a791b305c7355d8392c30d91b
 pytest==8.3.2 ; python_version >= "3.11" and python_version < "4.0" \
     --hash=sha256:4ba08f9ae7dcf84ded419494d229b48d0903ea6407b030eaec46df5e6a73bba5 \
     --hash=sha256:c132345d12ce551242c87269de812483f5bcc87cdbb4722e48487ba194f9fdce

--- a/tasks/split_pdfs.py
+++ b/tasks/split_pdfs.py
@@ -2,7 +2,7 @@ import os
 import zipfile
 import io
 from invoke import task
-from PyPDF2 import PdfReader, PdfWriter
+from pypdf import PdfReader, PdfWriter
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from tqdm import tqdm
 import json


### PR DESCRIPTION
This removes the warning when running `pytest`:

```
DeprecationWarning: PyPDF2 is deprecated. Please move to the pypdf library instead.
```