### PR TITLE
exclude index.html from zip

### DIFF
--- a/tasks/zip_volumes.py
+++ b/tasks/zip_volumes.py
@@ -62,7 +62,8 @@ def get_case_files_of_volume(reporter, volume, file_type, bucket):
 
     for page in r2_paginator.paginate(Bucket=bucket, Prefix=prefix, PaginationConfig={"PageSize": 1000}):
         for item in page["Contents"]:
-            files_for_volumes.append(item["Key"])
+            if "/index.html" not in item["Key"]:
+                files_for_volumes.append(item["Key"])
 
     return files_for_volumes
 


### PR DESCRIPTION
If we run the index.html job before the zip job for any reason, the index.html file will be populated in the bucket and the subsequent zip job will pick up this file as well. To prevent this, I excluded that file from the case files.